### PR TITLE
fix: resolve full dependency chain in _run_upstream_templates

### DIFF
--- a/brasa/engine/dependency_resolver.py
+++ b/brasa/engine/dependency_resolver.py
@@ -321,7 +321,7 @@ def _run_upstream_templates(
 
         try:
             if template_type == "etl":
-                report = process_etl(producer)
+                report = process_etl(producer, resolve_dependencies=True)
             else:
                 report = process_marketdata(producer)
 

--- a/tests/test_dependency_freshness.py
+++ b/tests/test_dependency_freshness.py
@@ -194,4 +194,6 @@ class TestRunUpstreamSkipsFresh:
                 graph,
                 required=True,
             )
-            mock_etl.assert_called_once_with("b3-indexes-consolidated")
+            mock_etl.assert_called_once_with(
+                "b3-indexes-consolidated", resolve_dependencies=True
+            )

--- a/tests/test_dependency_resolver.py
+++ b/tests/test_dependency_resolver.py
@@ -343,7 +343,7 @@ def test_run_upstream_etl_template():
             required=True,
         )
 
-    mock_etl.assert_called_once_with("upstream-etl")
+    mock_etl.assert_called_once_with("upstream-etl", resolve_dependencies=True)
 
 
 def test_run_upstream_download_template():
@@ -365,6 +365,34 @@ def test_run_upstream_download_template():
         )
 
     mock_dl.assert_called_once_with("upstream-dl")
+
+
+def test_run_upstream_etl_uses_resolve_dependencies():
+    """process_etl is called with resolve_dependencies=True so the full
+    ancestor chain (downloads, intermediate ETLs) is processed before
+    the target ETL runs.
+
+    Regression test for: b3-company-info downloads not processed before
+    b3-companies-names ETL when running companies-b3.yaml download plan.
+    """
+    from brasa.engine.dependency_resolver import _run_upstream_templates
+
+    graph = _make_graph(producer="b3-companies-names", template_type="etl")
+    mock_report = _make_report(success=True)
+
+    with patch("brasa.engine.api.process_etl", return_value=mock_report) as mock_etl:
+        _run_upstream_templates(
+            "b3-company-details",
+            "codeCVM",
+            ["staging.b3-companies-names"],
+            graph,
+            required=True,
+        )
+
+    # The critical assertion: resolve_dependencies=True ensures the orchestrator
+    # processes the full chain (e.g., process_marketdata for b3-company-info
+    # before running b3-companies-names ETL)
+    mock_etl.assert_called_once_with("b3-companies-names", resolve_dependencies=True)
 
 
 def test_run_upstream_required_raises_on_report_failure():


### PR DESCRIPTION
## Summary

Pass `resolve_dependencies=True` to `process_etl()` so the `PipelineOrchestrator` processes all ancestor templates before running the target ETL. This ensures freshly-downloaded data (e.g., b3-company-info) is processed into parquet before downstream ETLs (e.g., b3-companies-names) consume it.

Previously, the dependency resolver called `process_etl()` with the default `resolve_dependencies=False`, causing ETLs to run on stale input data when a download plan downloaded but did not process upstream templates between tasks.

## Changes

- **brasa/engine/dependency_resolver.py:324** - Pass `resolve_dependencies=True` to `process_etl()`
- **tests/test_dependency_resolver.py** - Updated test assertion and added regression test
- **tests/test_dependency_freshness.py** - Updated test assertion for consistency

## Test Plan

- [x] All existing tests pass (731 passed)
- [x] New regression test verifies `resolve_dependencies=True` is passed
- [x] Ruff linting and formatting passes
- [x] Pre-commit hooks pass
- [x] Commit message follows conventional commits

Fixes: b3-company-info downloads not processed before b3-companies-names ETL when running companies-b3.yaml download plan.