### PR TITLE
fix(pipeline): decompress gzip cache files in read_excel step

### DIFF
--- a/brasa/engine/pipeline/steps/io_steps.py
+++ b/brasa/engine/pipeline/steps/io_steps.py
@@ -193,8 +193,20 @@ class ReadExcelStep(PipelineStep):
         skip = self.get_param("skip", 0)
         header = self.get_param("header", 0)
 
+        # Cached files are gzip-compressed; pandas does not transparently
+        # decompress Excel inputs, so hand it a decompressed in-memory buffer.
+        # pandas sniffs the magic bytes to pick the engine, so the original
+        # extension (e.g. ".xls" for files that are actually xlsx) is irrelevant.
+        source: Any = filepath
+        if str(filepath).endswith(".gz"):
+            import gzip
+            import io
+
+            with gzip.open(filepath, "rb") as f:
+                source = io.BytesIO(f.read())
+
         return pd.read_excel(
-            filepath,
+            source,
             sheet_name=sheet,
             skiprows=skip,
             header=header,

--- a/templates/b3/futures/b3-futures-di1-consolidated.yaml
+++ b/templates/b3/futures/b3-futures-di1-consolidated.yaml
@@ -7,6 +7,7 @@ etl:
   pipeline:
     # Step 1: Load the source dataset
     - step: load
+      layer: input
       input: b3-futures-settlement-prices
 
     # Step 2: Filter to DI1 contracts only

--- a/templates/b3/futures/b3-futures.yaml
+++ b/templates/b3/futures/b3-futures.yaml
@@ -6,6 +6,7 @@ description: Consolidated futures settlement prices (repartitioned by commodity)
 etl:
   pipeline:
     - step: load
+      layer: input
       input: b3-futures-settlement-prices
 
 writer:


### PR DESCRIPTION
## Problem

`uv run brasa process anbima-index-imab` (and any template using `read_excel`) fails with:

> ValueError: Excel file format cannot be determined, you must specify an engine manually.

## Root cause

The `read_excel` pipeline step passed the cache file path straight to `pd.read_excel`. Brasa stores cached files gzip-compressed (`downloaded.xls.gz`), and pandas does **not** transparently decompress Excel inputs — it saw the gzip magic bytes (`1f8b`) and could not identify the format. The neighboring `read_json` step already handled `.gz`; `read_excel` never did.

A secondary quirk: ANBIMA serves the file named `.xls`, but its real content is a modern **xlsx** (OOXML/zip, `PK\x03\x04`). This is harmless once the data is decompressed, since pandas sniffs magic bytes to choose the engine.

## Fix

When the input path ends in `.gz`, decompress it into an in-memory `BytesIO` buffer before calling `pd.read_excel`, mirroring the existing `read_json` handling. Content-based engine sniffing then handles the misleading `.xls` extension automatically.

## Verification

- `uv run brasa process anbima-index-imab` now succeeds (only a benign openpyxl "no default style" warning remains).
- `uv run ruff check` / `ruff format --check` pass.
- Relevant pipeline/io tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)