### PR TITLE
fix(templates): anbima-index-imab daily snapshot, flat write, label normalize (WIL-66)

### DIFF
--- a/templates/anbima/anbima-index-imab.yaml
+++ b/templates/anbima/anbima-index-imab.yaml
@@ -3,6 +3,7 @@ description: Historico do indice IMA Geral (ANBIMA)
 downloader:
   verify_ssl: false
   function: brasa.downloaders.simple_download
+  extra-key: date
   url: https://s3-data-prd-use1-precos.s3.us-east-1.amazonaws.com/arquivos/indices-historico/IMAGERAL-HISTORICO.xls
   format: xls
 reader:
@@ -22,11 +23,14 @@ reader:
         "Variação 24 Meses (%)": return_24m_pct
         "Duration (d.u.)": duration_du
         "PMR": pmr
+    - step: str_replace
+      column: index_name
+      pattern: "IMA - Geral"
+      replacement: "IMA-GERAL"
     - step: apply_fields
       errors: coerce
 writer:
   layer: input
-  partitioning: [index_name]
 fields:
 - name: index_name
   description: Nome do indice

--- a/tests/test_anbima_index_imab.py
+++ b/tests/test_anbima_index_imab.py
@@ -1,0 +1,36 @@
+"""Tests for the anbima-index-imab template (WIL-66)."""
+
+from datetime import datetime
+
+import pandas as pd
+
+from brasa.engine.template import retrieve_template
+
+
+def test_imab_downloader_has_extra_key_date():
+    """Downloader uses extra-key: date so each day yields a distinct cache entry."""
+    tpl = retrieve_template("anbima-index-imab")
+    assert tpl.downloader._extra_key == "date"
+    assert tpl.downloader.extra_key == datetime.now().isoformat()[:10]
+
+
+def test_imab_writer_has_no_partitioning():
+    """The single-index history is written flat (no index_name partitioning)."""
+    tpl = retrieve_template("anbima-index-imab")
+    assert tpl.writer.partitioning == []
+
+
+def test_imab_pipeline_normalizes_index_name_label():
+    """The reader pipeline normalizes 'IMA - Geral' to the canonical 'IMA-GERAL'."""
+    tpl = retrieve_template("anbima-index-imab")
+    str_replace_steps = [
+        s
+        for s in tpl.reader._pipeline.steps
+        if s.__class__.__name__ == "StrReplaceStep"
+    ]
+    assert len(str_replace_steps) == 1
+    step = str_replace_steps[0]
+
+    df = pd.DataFrame({"index_name": ["IMA-GERAL", "IMA - Geral"]})
+    result = step.execute(df, None)
+    assert result["index_name"].unique().tolist() == ["IMA-GERAL"]


### PR DESCRIPTION
Fixes WIL-66.

## Problem

`templates/anbima/anbima-index-imab.yaml` ingests the cumulative file `IMAGERAL-HISTORICO.xls` (full IMA-GERAL history, single index). Three issues:

1. **No `extra-key: date`** — the cache ID is hashed from `(template, download_args)` only, so every download collapses into one entry and the file is never re-fetched; the stored history freezes at the first download.
2. **`partitioning: [index_name]` is unnecessary** — there is only one index in this file, so partitioning gives no pruning benefit.
3. **Inconsistent source labels** — the `Índice` column contains both `IMA-GERAL` and `IMA - Geral`, which splits the single index across two partitions and would make an `index_name = 'IMA-GERAL'` filter silently drop rows.

## Changes (all in `templates/anbima/anbima-index-imab.yaml`)

- Add `extra-key: date` to the downloader → one distinct cache entry per calendar day (`DAILY_SNAPSHOT`).
- Remove `partitioning: [index_name]` → writes one flat history. On reprocess, `existing_data_behavior="delete_matching"` overwrites the prior dataset with the newest, most-complete snapshot (constant storage, no duplicate rows).
- Add a `str_replace` step normalizing `"IMA - Geral"` → `"IMA-GERAL"` so the dataset is one clean time series.

## Tests

New `tests/test_anbima_index_imab.py` (3 tests): extra-key resolves to `date`, writer has no partitioning, and the pipeline's `StrReplaceStep` normalizes the label. Verified RED before the change, GREEN after.

`uv run pytest --no-integration`: 1014 passed. Ruff + pre-commit clean on changed files. (The one full-suite failure, `test_b3_cotahist_yearly_parsed_output_has_refdate`, is a pre-existing integration test that fails identically on `main`.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)